### PR TITLE
Fix README instructions mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ $ sudo apt install build-essential automake libtool cmake libbsd-dev libpcre3-de
 clone this repository
 
 ```sh
+$ cd citron
 $ git submodule update --init
-$ cd citron/autohell
+$ cd autohell
 $ autoreconf
 $ CFLAGS="-O3" CXXFLAGS="-O3" ./configure --with-stdpath=/usr/local/share/Citron --prefix=/usr/local --with-inject --with-ffi --with-inlineasm
 $ make


### PR DESCRIPTION
I just started building Citron and I found this mistake in the build instructions. You first have to `cd` into the `citron` directory and only then run `git submodule update --init`